### PR TITLE
Fix broken output in non TTY mode

### DIFF
--- a/lib/electron/program.js
+++ b/lib/electron/program.js
@@ -471,7 +471,7 @@ Program.prototype.colorize = function (noColors) {
   Object.keys(colors).forEach(function (color) {
     Object.defineProperty(String.prototype, color,
       { get: function () {
-          if (noColors || !self.opts.useColors) return this;
+          if (noColors || !self.opts.useColors) return this + '';
           return '\033[' + colors[color] + 'm' + this + '\033[0m';
         }
       , configurable: true


### PR DESCRIPTION
When using colour properties on a string when TTY mode is disabled (program.opts.useColors is false), the property value returned is the object representation of the string, instead of the string itself.

With TTY enabled:
![](http://i.stack.imgur.com/qiiLx.png)

With TTY disabled:
![](http://i.stack.imgur.com/sKFS9.png)

See  => http://stackoverflow.com/questions/27337089/node-js-coloured-text-from-stdout-gets-converted-to-object-notation-when-writte
